### PR TITLE
updating models.py for pydantic v2 compability

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ datamodel-codegen \
 
 ### Dependencies
 
-* pydantic==1.9.0
+* pydantic>=2.0.0
 * PyYAML>=6.0
 * mergedeep>=1.3.4
 
@@ -59,7 +59,8 @@ See also `tests/test_lib.py` for the different ways you may use the factory clas
 Alexandros Monastiriotis alexmondev@gmail.com
 
 ## Version History
-
+* 0.2.2
+    *  Update for pydantic v2    
 * 0.2.1
     * Updated layout + dependencies
 * 0.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ include_package_data = True
 package_dir =
     =src
 install_requires =
-    pydantic == 1.9.0
+    pydantic >= 2.0.0
     PyYAML >= 6.0
     mergedeep >= 1.3.4
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = compose-pydantic
-version = 0.2.1
+version = 0.2.2
 description = Parse Compose Specification data using Pydantic
 url = https://github.com/alexmon/compose-pydantic
 long_description = file: README.md

--- a/src/compose_pydantic/lib.py
+++ b/src/compose_pydantic/lib.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from os import PathLike
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 from mergedeep import merge, Strategy
 from yaml import safe_load
@@ -32,7 +32,9 @@ class DictSpecStrategy(ReadSpecStrategyABC):
 
 
 class FileSpecStrategy(ReadSpecStrategyABC):
-    def read_specs(self, source: StrOrBytesPath, overrides: list[StrOrBytesPath]) -> dict:
+    def read_specs(
+        self, source: StrOrBytesPath, overrides: list[StrOrBytesPath]
+    ) -> dict:
         """
         Read list of files adhere to Compose specification and return a dict
 
@@ -41,10 +43,10 @@ class FileSpecStrategy(ReadSpecStrategyABC):
                             same key values from rightmost files will be preserved
         :raises: any of (OSError, YAMLError, ValidationError)
         """
-        with open(source, 'r') as fh:
+        with open(source, "r") as fh:
             compose_data = safe_load(fh)
         for compose_file in overrides:
-            with open(compose_file, 'r') as fh:
+            with open(compose_file, "r") as fh:
                 data = safe_load(fh)
             merge(compose_data, data, strategy=Strategy.REPLACE)
 
@@ -67,7 +69,7 @@ class TextSpecStrategy(ReadSpecStrategyABC):
 
 
 class ComposeSpecificationFactory:
-    def __init__(self, strategy: ReadSpecStrategyABC = None):
+    def __init__(self, strategy: Optional[ReadSpecStrategyABC] = None):
         self._strategy = strategy if strategy else FileSpecStrategy()
 
     def __call__(self, source, overrides=[]) -> ComposeSpecification:

--- a/src/compose_pydantic/models.py
+++ b/src/compose_pydantic/models.py
@@ -7,12 +7,11 @@ from __future__ import annotations
 from enum import Enum
 from typing import Annotated, Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel, Field, StringConstraints
+from pydantic import BaseModel, Field, StringConstraints, RootModel, ConfigDict
 
 
 class Config1(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     source: Optional[str] = None
     target: Optional[str] = None
@@ -22,8 +21,7 @@ class Config1(BaseModel):
 
 
 class CredentialSpec(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     config: Optional[str] = None
     file: Optional[str] = None
@@ -37,23 +35,20 @@ class Condition(Enum):
 
 
 class DependsOn(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     condition: Condition
 
 
 class Extend(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     service: str
     file: Optional[str] = None
 
 
 class Logging(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     driver: Optional[str] = None
     options: Optional[
@@ -65,8 +60,7 @@ class Logging(BaseModel):
 
 
 class Port(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     mode: Optional[str] = None
     host_ip: Optional[str] = None
@@ -84,8 +78,7 @@ class PullPolicy(Enum):
 
 
 class Secret1(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     source: Optional[str] = None
     target: Optional[str] = None
@@ -95,8 +88,7 @@ class Secret1(BaseModel):
 
 
 class Ulimit(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     hard: int
     soft: int
@@ -108,8 +100,7 @@ class Selinux(Enum):
 
 
 class Bind(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     propagation: Optional[str] = None
     create_host_path: Optional[bool] = None
@@ -117,22 +108,19 @@ class Bind(BaseModel):
 
 
 class Volume2(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     nocopy: Optional[bool] = None
 
 
 class Tmpfs(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     size: Optional[Union[Annotated[int, Field(ge=0)], str]] = None
 
 
 class Volume1(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     type: str
     source: Optional[str] = None
@@ -145,8 +133,7 @@ class Volume1(BaseModel):
 
 
 class Healthcheck(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     disable: Optional[bool] = None
     interval: Optional[str] = None
@@ -162,8 +149,7 @@ class Order(Enum):
 
 
 class RollbackConfig(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     parallelism: Optional[int] = None
     delay: Optional[str] = None
@@ -179,8 +165,7 @@ class Order1(Enum):
 
 
 class UpdateConfig(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     parallelism: Optional[int] = None
     delay: Optional[str] = None
@@ -191,8 +176,7 @@ class UpdateConfig(BaseModel):
 
 
 class Limits(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     cpus: Optional[Union[float, str]] = None
     memory: Optional[str] = None
@@ -200,8 +184,7 @@ class Limits(BaseModel):
 
 
 class RestartPolicy(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     condition: Optional[str] = None
     delay: Optional[str] = None
@@ -210,15 +193,13 @@ class RestartPolicy(BaseModel):
 
 
 class Preference(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     spread: Optional[str] = None
 
 
 class Placement(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     constraints: Optional[List[str]] = None
     preferences: Optional[List[Preference]] = None
@@ -226,27 +207,24 @@ class Placement(BaseModel):
 
 
 class DiscreteResourceSpec(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     kind: Optional[str] = None
     value: Optional[float] = None
 
 
 class GenericResource(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     discrete_resource_spec: Optional[DiscreteResourceSpec] = None
 
 
-class GenericResources(BaseModel):
-    __root__: List[GenericResource]
+class GenericResources(RootModel):
+    root: List[GenericResource]
 
 
 class ConfigItem(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     subnet: Optional[str] = None
     ip_range: Optional[str] = None
@@ -257,8 +235,7 @@ class ConfigItem(BaseModel):
 
 
 class Ipam(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     driver: Optional[str] = None
     config: Optional[List[ConfigItem]] = None
@@ -268,15 +245,13 @@ class Ipam(BaseModel):
 
 
 class External(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     name: Optional[str] = None
 
 
 class External1(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     name: Optional[str] = None
 
@@ -289,12 +264,12 @@ class External3(BaseModel):
     name: Optional[str] = None
 
 
-class ListOfStrings(BaseModel):
-    __root__: List[str]
+class ListOfStrings(RootModel):
+    root: List[str]
 
 
-class ListOrDict(BaseModel):
-    __root__: Union[
+class ListOrDict(RootModel):
+    root: Union[
         Dict[
             Annotated[str, StringConstraints(pattern=r".+")],
             Optional[Union[str, float, bool]],
@@ -304,28 +279,25 @@ class ListOrDict(BaseModel):
 
 
 class BlkioLimit(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     path: Optional[str] = None
     rate: Optional[Union[int, str]] = None
 
 
 class BlkioWeight(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     path: Optional[str] = None
     weight: Optional[int] = None
 
 
-class Constraints(BaseModel):
-    __root__: Any
+class Constraints(RootModel):
+    root: Any
 
 
 class BuildItem(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     context: Optional[str] = None
     dockerfile: Optional[str] = None
@@ -342,8 +314,7 @@ class BuildItem(BaseModel):
 
 
 class BlkioConfig(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     device_read_bps: Optional[List[BlkioLimit]] = None
     device_read_iops: Optional[List[BlkioLimit]] = None
@@ -354,8 +325,7 @@ class BlkioConfig(BaseModel):
 
 
 class Network1(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     aliases: Optional[ListOfStrings] = None
     ipv4_address: Optional[str] = None
@@ -365,8 +335,7 @@ class Network1(BaseModel):
 
 
 class Device(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     capabilities: Optional[ListOfStrings] = None
     count: Optional[Union[str, int]] = None
@@ -375,13 +344,12 @@ class Device(BaseModel):
     options: Optional[ListOrDict] = None
 
 
-class Devices(BaseModel):
-    __root__: List[Device]
+class Devices(RootModel):
+    root: List[Device]
 
 
 class Network(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     name: Optional[str] = None
     driver: Optional[str] = None
@@ -397,8 +365,7 @@ class Network(BaseModel):
 
 
 class Volume(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     name: Optional[str] = None
     driver: Optional[str] = None
@@ -410,8 +377,7 @@ class Volume(BaseModel):
 
 
 class Secret(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     name: Optional[str] = None
     file: Optional[str] = None
@@ -425,8 +391,7 @@ class Secret(BaseModel):
 
 
 class Config(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     name: Optional[str] = None
     file: Optional[str] = None
@@ -435,13 +400,12 @@ class Config(BaseModel):
     template_driver: Optional[str] = None
 
 
-class StringOrList(BaseModel):
-    __root__: Union[str, ListOfStrings]
+class StringOrList(RootModel):
+    root: Union[str, ListOfStrings]
 
 
 class Reservations(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     cpus: Optional[Union[float, str]] = None
     memory: Optional[str] = None
@@ -450,16 +414,14 @@ class Reservations(BaseModel):
 
 
 class Resources(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     limits: Optional[Limits] = None
     reservations: Optional[Reservations] = None
 
 
 class Deployment(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     mode: Optional[str] = None
     endpoint_mode: Optional[str] = None
@@ -473,8 +435,7 @@ class Deployment(BaseModel):
 
 
 class Service(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     deploy: Optional[Deployment] = None
     build: Optional[Union[str, BuildItem]] = None
@@ -576,8 +537,7 @@ class Service(BaseModel):
 
 
 class ComposeSpecification(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
     version: Optional[str] = Field(
         None, description="declared for backward compatibility, ignored."

--- a/src/compose_pydantic/models.py
+++ b/src/compose_pydantic/models.py
@@ -5,14 +5,14 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Annotated, Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel, Extra, Field, conint, constr
+from pydantic import BaseModel, Field, StringConstraints
 
 
 class Config1(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     source: Optional[str] = None
     target: Optional[str] = None
@@ -23,7 +23,7 @@ class Config1(BaseModel):
 
 class CredentialSpec(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     config: Optional[str] = None
     file: Optional[str] = None
@@ -31,21 +31,21 @@ class CredentialSpec(BaseModel):
 
 
 class Condition(Enum):
-    service_started = 'service_started'
-    service_healthy = 'service_healthy'
-    service_completed_successfully = 'service_completed_successfully'
+    service_started = "service_started"
+    service_healthy = "service_healthy"
+    service_completed_successfully = "service_completed_successfully"
 
 
 class DependsOn(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     condition: Condition
 
 
 class Extend(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     service: str
     file: Optional[str] = None
@@ -53,15 +53,20 @@ class Extend(BaseModel):
 
 class Logging(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     driver: Optional[str] = None
-    options: Optional[Dict[constr(regex=r'^.+$'), Optional[Union[str, float]]]] = None
+    options: Optional[
+        Dict[
+            Annotated[str, StringConstraints(pattern=r"^.+$")],
+            Optional[Union[str, float]],
+        ]
+    ] = None
 
 
 class Port(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     mode: Optional[str] = None
     host_ip: Optional[str] = None
@@ -71,16 +76,16 @@ class Port(BaseModel):
 
 
 class PullPolicy(Enum):
-    always = 'always'
-    never = 'never'
-    if_not_present = 'if_not_present'
-    build = 'build'
-    missing = 'missing'
+    always = "always"
+    never = "never"
+    if_not_present = "if_not_present"
+    build = "build"
+    missing = "missing"
 
 
 class Secret1(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     source: Optional[str] = None
     target: Optional[str] = None
@@ -91,20 +96,20 @@ class Secret1(BaseModel):
 
 class Ulimit(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     hard: int
     soft: int
 
 
 class Selinux(Enum):
-    z = 'z'
-    Z = 'Z'
+    z = "z"
+    Z = "Z"
 
 
 class Bind(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     propagation: Optional[str] = None
     create_host_path: Optional[bool] = None
@@ -113,21 +118,21 @@ class Bind(BaseModel):
 
 class Volume2(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     nocopy: Optional[bool] = None
 
 
 class Tmpfs(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
-    size: Optional[Union[conint(ge=0), str]] = None
+    size: Optional[Union[Annotated[int, Field(ge=0)], str]] = None
 
 
 class Volume1(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     type: str
     source: Optional[str] = None
@@ -141,7 +146,7 @@ class Volume1(BaseModel):
 
 class Healthcheck(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     disable: Optional[bool] = None
     interval: Optional[str] = None
@@ -152,13 +157,13 @@ class Healthcheck(BaseModel):
 
 
 class Order(Enum):
-    start_first = 'start-first'
-    stop_first = 'stop-first'
+    start_first = "start-first"
+    stop_first = "stop-first"
 
 
 class RollbackConfig(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     parallelism: Optional[int] = None
     delay: Optional[str] = None
@@ -169,13 +174,13 @@ class RollbackConfig(BaseModel):
 
 
 class Order1(Enum):
-    start_first = 'start-first'
-    stop_first = 'stop-first'
+    start_first = "start-first"
+    stop_first = "stop-first"
 
 
 class UpdateConfig(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     parallelism: Optional[int] = None
     delay: Optional[str] = None
@@ -187,7 +192,7 @@ class UpdateConfig(BaseModel):
 
 class Limits(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     cpus: Optional[Union[float, str]] = None
     memory: Optional[str] = None
@@ -196,7 +201,7 @@ class Limits(BaseModel):
 
 class RestartPolicy(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     condition: Optional[str] = None
     delay: Optional[str] = None
@@ -206,14 +211,14 @@ class RestartPolicy(BaseModel):
 
 class Preference(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     spread: Optional[str] = None
 
 
 class Placement(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     constraints: Optional[List[str]] = None
     preferences: Optional[List[Preference]] = None
@@ -222,7 +227,7 @@ class Placement(BaseModel):
 
 class DiscreteResourceSpec(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     kind: Optional[str] = None
     value: Optional[float] = None
@@ -230,7 +235,7 @@ class DiscreteResourceSpec(BaseModel):
 
 class GenericResource(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     discrete_resource_spec: Optional[DiscreteResourceSpec] = None
 
@@ -241,33 +246,37 @@ class GenericResources(BaseModel):
 
 class ConfigItem(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     subnet: Optional[str] = None
     ip_range: Optional[str] = None
     gateway: Optional[str] = None
-    aux_addresses: Optional[Dict[constr(regex=r'^.+$'), str]] = None
+    aux_addresses: Optional[
+        Dict[Annotated[str, StringConstraints(pattern=r"^.+$")], str]
+    ] = None
 
 
 class Ipam(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     driver: Optional[str] = None
     config: Optional[List[ConfigItem]] = None
-    options: Optional[Dict[constr(regex=r'^.+$'), str]] = None
+    options: Optional[Dict[Annotated[str, StringConstraints(pattern=r"^.+$")], str]] = (
+        None
+    )
 
 
 class External(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     name: Optional[str] = None
 
 
 class External1(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     name: Optional[str] = None
 
@@ -286,13 +295,17 @@ class ListOfStrings(BaseModel):
 
 class ListOrDict(BaseModel):
     __root__: Union[
-        Dict[constr(regex=r'.+'), Optional[Union[str, float, bool]]], List[str]
+        Dict[
+            Annotated[str, StringConstraints(pattern=r".+")],
+            Optional[Union[str, float, bool]],
+        ],
+        List[str],
     ]
 
 
 class BlkioLimit(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     path: Optional[str] = None
     rate: Optional[Union[int, str]] = None
@@ -300,7 +313,7 @@ class BlkioLimit(BaseModel):
 
 class BlkioWeight(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     path: Optional[str] = None
     weight: Optional[int] = None
@@ -312,7 +325,7 @@ class Constraints(BaseModel):
 
 class BuildItem(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     context: Optional[str] = None
     dockerfile: Optional[str] = None
@@ -330,7 +343,7 @@ class BuildItem(BaseModel):
 
 class BlkioConfig(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     device_read_bps: Optional[List[BlkioLimit]] = None
     device_read_iops: Optional[List[BlkioLimit]] = None
@@ -342,7 +355,7 @@ class BlkioConfig(BaseModel):
 
 class Network1(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     aliases: Optional[ListOfStrings] = None
     ipv4_address: Optional[str] = None
@@ -353,7 +366,7 @@ class Network1(BaseModel):
 
 class Device(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     capabilities: Optional[ListOfStrings] = None
     count: Optional[Union[str, int]] = None
@@ -368,11 +381,13 @@ class Devices(BaseModel):
 
 class Network(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     name: Optional[str] = None
     driver: Optional[str] = None
-    driver_opts: Optional[Dict[constr(regex=r'^.+$'), Union[str, float]]] = None
+    driver_opts: Optional[
+        Dict[Annotated[str, StringConstraints(pattern=r"^.+$")], Union[str, float]]
+    ] = None
     ipam: Optional[Ipam] = None
     external: Optional[External] = None
     internal: Optional[bool] = None
@@ -383,31 +398,35 @@ class Network(BaseModel):
 
 class Volume(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     name: Optional[str] = None
     driver: Optional[str] = None
-    driver_opts: Optional[Dict[constr(regex=r'^.+$'), Union[str, float]]] = None
+    driver_opts: Optional[
+        Dict[Annotated[str, StringConstraints(pattern=r"^.+$")], Union[str, float]]
+    ] = None
     external: Optional[External1] = None
     labels: Optional[ListOrDict] = None
 
 
 class Secret(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     name: Optional[str] = None
     file: Optional[str] = None
     external: Optional[External2] = None
     labels: Optional[ListOrDict] = None
     driver: Optional[str] = None
-    driver_opts: Optional[Dict[constr(regex=r'^.+$'), Union[str, float]]] = None
+    driver_opts: Optional[
+        Dict[Annotated[str, StringConstraints(pattern=r"^.+$")], Union[str, float]]
+    ] = None
     template_driver: Optional[str] = None
 
 
 class Config(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     name: Optional[str] = None
     file: Optional[str] = None
@@ -422,7 +441,7 @@ class StringOrList(BaseModel):
 
 class Reservations(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     cpus: Optional[Union[float, str]] = None
     memory: Optional[str] = None
@@ -432,7 +451,7 @@ class Reservations(BaseModel):
 
 class Resources(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     limits: Optional[Limits] = None
     reservations: Optional[Reservations] = None
@@ -440,7 +459,7 @@ class Resources(BaseModel):
 
 class Deployment(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     mode: Optional[str] = None
     endpoint_mode: Optional[str] = None
@@ -455,7 +474,7 @@ class Deployment(BaseModel):
 
 class Service(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     deploy: Optional[Deployment] = None
     build: Optional[Union[str, BuildItem]] = None
@@ -466,8 +485,8 @@ class Service(BaseModel):
     command: Optional[Union[str, List[str]]] = None
     configs: Optional[List[Union[str, Config1]]] = None
     container_name: Optional[str] = None
-    cpu_count: Optional[conint(ge=0)] = None
-    cpu_percent: Optional[conint(ge=0, le=100)] = None
+    cpu_count: Optional[Annotated[int, Field(ge=0)]] = None
+    cpu_percent: Optional[Annotated[int, Field(ge=0, le=100)]] = None
     cpu_shares: Optional[Union[float, str]] = None
     cpu_quota: Optional[Union[float, str]] = None
     cpu_period: Optional[Union[float, str]] = None
@@ -477,7 +496,13 @@ class Service(BaseModel):
     cpuset: Optional[str] = None
     credential_spec: Optional[CredentialSpec] = None
     depends_on: Optional[
-        Union[ListOfStrings, Dict[constr(regex=r'^[a-zA-Z0-9._-]+$'), DependsOn]]
+        Union[
+            ListOfStrings,
+            Dict[
+                Annotated[str, StringConstraints(pattern=r"^[a-zA-Z0-9._-]+$")],
+                DependsOn,
+            ],
+        ]
     ] = None
     device_cgroup_rules: Optional[ListOfStrings] = None
     devices: Optional[List[str]] = None
@@ -510,11 +535,15 @@ class Service(BaseModel):
     network_mode: Optional[str] = None
     networks: Optional[
         Union[
-            ListOfStrings, Dict[constr(regex=r'^[a-zA-Z0-9._-]+$'), Optional[Network1]]
+            ListOfStrings,
+            Dict[
+                Annotated[str, StringConstraints(pattern=r"^[a-zA-Z0-9._-]+$")],
+                Optional[Network1],
+            ],
         ]
     ] = None
     oom_kill_disable: Optional[bool] = None
-    oom_score_adj: Optional[conint(ge=-1000, le=1000)] = None
+    oom_score_adj: Optional[Annotated[int, Field(ge=-1000, le=1000)]] = None
     pid: Optional[Optional[str]] = None
     pids_limit: Optional[Union[float, str]] = None
     platform: Optional[str] = None
@@ -536,7 +565,9 @@ class Service(BaseModel):
     storage_opt: Optional[Dict[str, Any]] = None
     tmpfs: Optional[StringOrList] = None
     tty: Optional[bool] = None
-    ulimits: Optional[Dict[constr(regex=r'^[a-z]+$'), Union[int, Ulimit]]] = None
+    ulimits: Optional[
+        Dict[Annotated[str, StringConstraints(pattern=r"^[a-z]+$")], Union[int, Ulimit]]
+    ] = None
     user: Optional[str] = None
     userns_mode: Optional[str] = None
     volumes: Optional[List[Union[str, Volume1]]] = None
@@ -546,17 +577,27 @@ class Service(BaseModel):
 
 class ComposeSpecification(BaseModel):
     class Config:
-        extra = Extra.forbid
+        extra = "forbid"
 
     version: Optional[str] = Field(
-        None, description='declared for backward compatibility, ignored.'
+        None, description="declared for backward compatibility, ignored."
     )
     name: Optional[str] = Field(
         None,
-        description='define the Compose project name, until user defines one explicitly.',
+        description="define the Compose project name, until user defines one explicitly.",
     )
-    services: Optional[Dict[constr(regex=r'^[a-zA-Z0-9._-]+$'), Service]] = None
-    networks: Optional[Dict[constr(regex=r'^[a-zA-Z0-9._-]+$'), Network]] = None
-    volumes: Optional[Dict[constr(regex=r'^[a-zA-Z0-9._-]+$'), Volume]] = None
-    secrets: Optional[Dict[constr(regex=r'^[a-zA-Z0-9._-]+$'), Secret]] = None
-    configs: Optional[Dict[constr(regex=r'^[a-zA-Z0-9._-]+$'), Config]] = None
+    services: Optional[
+        Dict[Annotated[str, StringConstraints(pattern=r"^[a-zA-Z0-9._-]+$")], Service]
+    ] = None
+    networks: Optional[
+        Dict[Annotated[str, StringConstraints(pattern=r"^[a-zA-Z0-9._-]+$")], Network]
+    ] = None
+    volumes: Optional[
+        Dict[Annotated[str, StringConstraints(pattern=r"^[a-zA-Z0-9._-]+$")], Volume]
+    ] = None
+    secrets: Optional[
+        Dict[Annotated[str, StringConstraints(pattern=r"^[a-zA-Z0-9._-]+$")], Secret]
+    ] = None
+    configs: Optional[
+        Dict[Annotated[str, StringConstraints(pattern=r"^[a-zA-Z0-9._-]+$")], Config]
+    ] = None


### PR DESCRIPTION
This PR updates models.py to ensure full compatibility with Pydantic v2, aligning with the latest best practices and removing deprecated patterns from Pydantic v1.

Key Changes
• Replaced deprecated constr with Annotated and StringConstraints
• Replaced BaseModel.Config with model_config (as per v2)