### PR TITLE
support parsing volumes which are not defined

### DIFF
--- a/src/compose_pydantic/models.py
+++ b/src/compose_pydantic/models.py
@@ -557,6 +557,6 @@ class ComposeSpecification(BaseModel):
     )
     services: Optional[Dict[constr(regex=r'^[a-zA-Z0-9._-]+$'), Service]] = None
     networks: Optional[Dict[constr(regex=r'^[a-zA-Z0-9._-]+$'), Network]] = None
-    volumes: Optional[Dict[constr(regex=r'^[a-zA-Z0-9._-]+$'), Volume]] = None
+    volumes: Optional[Dict[constr(regex=r'^[a-zA-Z0-9._-]+$'), Optional[Volume]]] = None
     secrets: Optional[Dict[constr(regex=r'^[a-zA-Z0-9._-]+$'), Secret]] = None
     configs: Optional[Dict[constr(regex=r'^[a-zA-Z0-9._-]+$'), Config]] = None

--- a/tests/compose/docker-compose.yml
+++ b/tests/compose/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   db:
     image: postgres
     volumes:
-      - ./data/db:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql/data
     environment:
       - POSTGRES_NAME=postgres
       - POSTGRES_USER=postgres
@@ -23,3 +23,5 @@ services:
     depends_on:
       - db
 
+volumes:
+  db-data:


### PR DESCRIPTION
It's a fairly common pattern to have a volume defined which has the default value.

Docker itself supports this pattern, but this package currently errors out if a value is not explicitly provided. 